### PR TITLE
Handling von verschiedenen Netzen (FHEM Haupt IP vs. Gateway in eigenem VLAN)

### DIFF
--- a/FHEM/71_XiaomiSmartHome.pm
+++ b/FHEM/71_XiaomiSmartHome.pm
@@ -83,7 +83,7 @@ sub XiaomiSmartHome_Initialize($) {
     $hash->{ReadFn}     = 'XiaomiSmartHome_Read';
 	$hash->{ReadyFn}    = 'XiaomiSmartHome_Ready';
     $hash->{WriteFn}    = 'XiaomiSmartHome_Write';
-	$hash->{AttrList}	= 'disable:1,0 ' .
+	$hash->{AttrList}	= 'disable:1,0 FHEMIP ' .
 						  $readingFnAttributes;
 
 	$hash->{MatchList} = { "1:XiaomiSmartHome_Device"   => ".*magnet.*",
@@ -309,16 +309,31 @@ sub XiaomiSmartHome_Reading ($@) {
 #####################################
 
 
-sub XiaomiSmartHome_getLocalIP(){
-  my $socket = IO::Socket::INET->new( 	Proto       => 'udp',
-										PeerAddr    => '8.8.8.8:53',    # google dns
-									);
-  return '<unknown>' if( !$socket );
-  my $ip = $socket->sockhost;
-  close( $socket );
-  return $ip if( $ip );
+sub XiaomiSmartHome_getLocalIP($){
 
-  return '<unknown>';
+        my ($hash) = @_;
+        my $name = $hash->{NAME};
+        my $attrFHEMIP = AttrVal($name, 'FHEMIP', undef);
+        my $socket;
+
+        if (defined $attrFHEMIP){
+                $socket = IO::Socket::INET->new(
+                        Proto       => 'udp',
+                        LocalAddr   => $attrFHEMIP,
+                        PeerAddr    => '8.8.8.8:53',    # google dns
+                );
+        }else{
+                $socket = IO::Socket::INET->new(
+                        Proto       => 'udp',
+                        PeerAddr    => '8.8.8.8:53',    # google dns
+                );
+        }
+        return '<unknown>' if( !$socket );
+        my $ip = $socket->sockhost;
+        close( $socket );
+        return $ip if( $ip );
+        return '<unknown>';
+
 }
 #####################################
 
@@ -396,7 +411,7 @@ sub XiaomiSmartHome_Define($$) {
 	$hash->{VERSION}  = $version;
     $hash->{GATEWAY} = $param[2];
 	$hash->{helper}{JSON} = JSON->new->utf8();
-	$hash->{FHEMIP} = XiaomiSmartHome_getLocalIP();
+	$hash->{FHEMIP} = XiaomiSmartHome_getLocalIP($hash);
 	$hash->{STATE} = "initialized";
 	$hash->{helper}{host} = $definition;
 	if( $hash->{GATEWAY} !~ m/^\d+\.\d+\.\d+\.\d+$/ ){

--- a/FHEM/71_XiaomiSmartHome.pm
+++ b/FHEM/71_XiaomiSmartHome.pm
@@ -48,7 +48,7 @@ use SetExtensions;
 sub XiaomiSmartHome_updateSingleReading($$);
 my $iv="\x17\x99\x6d\x09\x3d\x28\xdd\xb3\xba\x69\x5a\x2e\x6f\x58\x56\x2e";
 
-my $version = "1.41";
+my $version = "1.42";
 
 my %XiaomiSmartHome_gets = (
 	"getDevices"	=> ["get_id_list", '^.+get_id_list_ack' ],

--- a/controls_mish.txt
+++ b/controls_mish.txt
@@ -1,2 +1,2 @@
-UPD 2019-04-26_11:40:51 40758 FHEM/71_XiaomiSmartHome.pm
+UPD 2020-04-15_11:40:51 41287 FHEM/71_XiaomiSmartHome.pm
 UPD 2019-03-20_11:32:54 30100 FHEM/71_XiaomiSmartHome_Device.pm


### PR DESCRIPTION
Hallo,

da mein Gateway nicht im Hauptnetz meiner FHEM Instanz ist sondern in einem eigene VLAN, welches als zusätzlich Interface auf dem FHEM Server angelegt ist, kann ich das Modul nur mit dieser Anpassung nutzen.

Wäre schön, wenn du diese Anpassungen mit aufnehmen würdest.
Anpassungen am Code zu deinen Wünschen sind gerne gesehen.

Bei Fragen einfach hier melden.


Grüße

Christian